### PR TITLE
Fix wrong mime type for svg images

### DIFF
--- a/src/htmlmerger/htmlmerger/htmlmerger.py
+++ b/src/htmlmerger/htmlmerger/htmlmerger.py
@@ -52,7 +52,12 @@ class HtmlMerger(HTMLParser):
       return None
 
     imageExtension = os.path.splitext (imgPathRel)[1][1:]
-    imageFormat = imageExtension
+
+    # SVG is an image format where the file extension is not the mime type
+    if imageExtension == "svg":
+        imageFormat = "svg+xml"
+    else:
+        imageFormat = imageExtension
 
     # convert image data into browser-undertandable src value
     image_bytes = getFileContentBytes (imgPathFull)


### PR DESCRIPTION
Sadly the mime type for `.svg` is `image/svg+xml` which results in "broken" svg files.

Currently:
`src="data:image/svg;base64,...`

With PR:
`src="data:image/svg+xml;base64,...`


Feel free to edit (e.g. fix the line ending)